### PR TITLE
Add Replit configuration

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,1 @@
+run = "python3 main.py"

--- a/main.py
+++ b/main.py
@@ -1,0 +1,20 @@
+import asyncio
+from proxybroker import Broker
+
+async def show(proxies):
+    while True:
+        proxy = await proxies.get()
+        if proxy is None:
+            break
+        print(f"Found proxy: {proxy}")
+
+async def main():
+    proxies = asyncio.Queue()
+    broker = Broker(proxies)
+    await asyncio.gather(
+        broker.find(types=['HTTP', 'HTTPS'], limit=10),
+        show(proxies),
+    )
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a simple demo script
- add Replit config so `Run` works out of the box

## Testing
- `pytest -q` *(fails: 21 failed, 29 passed, 25 skipped, 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68547f4ec6e0832a8c9a95687aac139c